### PR TITLE
build(rust): bump version to 1.80.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     with:
       # push_remote_flag: ${{ github.ref == 'refs/heads/main' }}
       push_remote_flag: ${{ github.event.pull_request.merged == true }}
+      docker_bake_targets: 'image-basic'
+      docker-metadata-flavor-suffix: '' # default is '', can add as: -alpine -debian
     secrets:
       DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"
 
@@ -59,7 +61,9 @@ jobs:
       - version
     uses: ./.github/workflows/docker-buildx-bake-hubdocker-tag.yml
     if: startsWith(github.ref, 'refs/tags/')
-    # with:
+    with:
+      docker_bake_targets: 'image-basic'
+      docker-metadata-flavor-suffix: '' # default is '', can add as: -alpine -debian
       # push_remote_flag: true # default is true
     secrets:
       DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -9,7 +9,7 @@
 name: docker-buildx-bake-hubdocker-latest
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-latest
+  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-${{ inputs.docker_bake_targets }}-latest
   # cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
   cancel-in-progress: false
 
@@ -21,6 +21,21 @@ on:
         default: false
         required: false
         type: boolean
+      docker_bake_targets:
+        description: 'docker bake targets'
+        default: 'image-basic'
+        required: false
+        type: string
+      docker-metadata-flavor-suffix:
+        description: 'docker metadata flavor suffix just like: -alpine -debian'
+        default: ''
+        required: false
+        type: string
+      docker_bake_matrix_target_postfix:
+        description: 'docker build matrix target postfix'
+        default: '-all'
+        required: false
+        type: string
       docker_bake_config_file_path:
         description: 'docker-bake file name'
         default: './docker-bake.hcl'
@@ -31,6 +46,11 @@ on:
         default: false
         required: false
         type: boolean
+      docker-build-timeout-minutes:
+        description: 'docker build timeout minutes'
+        default: 30
+        required: false
+        type: number
     secrets:
       DOCKERHUB_TOKEN:
         description: 'docker hub token'
@@ -54,7 +74,7 @@ jobs:
         name: Create matrix
         id: platforms
         run: |
-          echo "matrix=$(docker buildx bake image-all --print | jq -cr '.target."image-all".platforms')" >>${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}}".platforms')" >>${GITHUB_OUTPUT}
       -
         name: Show matrix
         run: |
@@ -89,18 +109,23 @@ jobs:
           tags: |
             # set latest tag for main branch https://github.com/docker/metadata-action#latest-tag
             type=raw,value=latest,enable=true
+          flavor: |
+            latest=auto
+            suffix=${{ inputs.docker-metadata-flavor-suffix }}
+
       -
         name: Rename meta bake definition file
         run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/bake-meta.json"
+          mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/bake-meta.json
+          name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -128,12 +153,12 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v5
-        timeout-minutes: 30 # default 360
+        timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
             ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/bake-meta.json
-          targets: image
+            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
           sbom: false
@@ -145,19 +170,26 @@ jobs:
             *.cache-to=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
             *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
 
+      - name: Extract container image digest from bake output
+        id: bake-output-container-image-digest
+        run: |
+          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+
       -
         name: Upload digest
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
+          name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/*
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -165,8 +197,8 @@ jobs:
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
 
   merge:
@@ -179,7 +211,8 @@ jobs:
       -
         name: check temp path
         run: |
-          ls -al ${{ runner.temp }}
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
 
       -
         name: Download meta bake definition
@@ -187,8 +220,8 @@ jobs:
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}
+          pattern: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           merge-multiple: true
 
       -
@@ -197,15 +230,15 @@ jobs:
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}/digests/
+          pattern: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
           merge-multiple: true
 
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
       -
         name: Set up Docker Buildx
@@ -220,12 +253,12 @@ jobs:
 
       -
         name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests/
+        working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -128,6 +128,7 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v5
+        timeout-minutes: 30 # default 360
         with:
           files: |
             ${{ inputs.docker_bake_config_file_path }}

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -9,7 +9,7 @@
 name: docker-buildx-bake-hubdocker-tag
 
 # concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-tag
+#   group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-${{ inputs.docker_bake_targets }}-tag
 #   cancel-in-progress: false
 
 on:
@@ -20,6 +20,21 @@ on:
         default: true
         required: false
         type: boolean
+      docker_bake_targets:
+        description: 'docker bake targets'
+        default: 'image-basic'
+        required: false
+        type: string
+      docker-metadata-flavor-suffix:
+        description: 'docker metadata flavor suffix just like: -alpine -debian'
+        default: ''
+        required: false
+        type: string
+      docker_bake_matrix_target_postfix:
+        description: 'docker build matrix target postfix'
+        default: '-all'
+        required: false
+        type: string
       docker_bake_config_file_path:
         description: 'docker-bake file name'
         default: './docker-bake.hcl'
@@ -30,6 +45,11 @@ on:
         default: false
         required: false
         type: boolean
+      docker-build-timeout-minutes:
+        description: 'docker build timeout minutes'
+        default: 30
+        required: false
+        type: number
     secrets:
       DOCKERHUB_TOKEN:
         description: 'docker hub token'
@@ -53,7 +73,7 @@ jobs:
         name: Create matrix
         id: platforms
         run: |
-          echo "matrix=$(docker buildx bake image-all --print | jq -cr '.target."image-all".platforms')" >>${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}}".platforms')" >>${GITHUB_OUTPUT}
       -
         name: Show matrix
         run: |
@@ -88,18 +108,23 @@ jobs:
           tags: |
             # type semver https://github.com/docker/metadata-action#typesemver
             type=semver,pattern={{version}}
+          flavor: |
+            latest=auto
+            suffix=${{ inputs.docker-metadata-flavor-suffix }}
+
       -
         name: Rename meta bake definition file
         run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/bake-meta.json"
+          mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/bake-meta.json
+          name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -127,11 +152,12 @@ jobs:
         name: Build
         id: bake
         uses: docker/bake-action@v5
+        timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
             ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/bake-meta.json
-          targets: image
+            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
           sbom: false
@@ -143,19 +169,26 @@ jobs:
             *.cache-to=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
             *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
 
+      - name: Extract container image digest from bake output
+        id: bake-output-container-image-digest
+        run: |
+          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+
       -
         name: Upload digest
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
+          name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/*
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -163,8 +196,8 @@ jobs:
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
 
   merge:
@@ -177,7 +210,8 @@ jobs:
       -
         name: check temp path
         run: |
-          ls -al ${{ runner.temp }}
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
 
       -
         name: Download meta bake definition
@@ -185,8 +219,8 @@ jobs:
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}
+          pattern: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           merge-multiple: true
 
       -
@@ -195,15 +229,15 @@ jobs:
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}/digests/
+          pattern: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
           merge-multiple: true
 
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
       -
         name: Set up Docker Buildx
@@ -218,12 +252,12 @@ jobs:
 
       -
         name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests/
+        working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.80.0
+FROM rust:1.80.1
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.80.0
+ROOT_PARENT_SWITCH_TAG :=1.80.1
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ docker run --rm \
   sinlov/rust-runtime-debian:latest \
   rustup show
 
-# check 1.80.0 build env
+# check 1.80.1 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.80.0 \
+  sinlov/rust-runtime-debian:1.80.1 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -66,7 +66,7 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.80.0`
+- rust version `1.80.1`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.80.0
+FROM rust:1.80.1
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,20 +12,25 @@ group "default" {
   targets = ["image-local"]
 }
 
-target "image" {
-  inherits = ["docker-metadata-action"]
-}
-
 target "image-local" {
   inherits = ["image"]
   output = ["type=docker"]
 }
 
+// this config use by `docker_bake_targets` most of time is `image-basic`
+// https://docs.docker.com/build/bake/reference/#target
+// show config as: docker buildx bake --print image-basic
+target "image-basic" {
+  inherits = ["docker-metadata-action"]
+  context = "."
+  dockerfile = "Dockerfile"
+}
+
 // must check by parent image support multi-platform
 // doc: https://docs.docker.com/reference/cli/docker/buildx/build/#platform
 // most of can as: linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/arm/v6 linux/ppc64le linux/s390x
-target "image-all" {
-  inherits = ["image"]
+target "image-basic-all" {
+  inherits = ["image-basic"]
   platforms = [
     "linux/amd64",
     "linux/386",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.80.0",
+  "version": "1.80.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
Update Dockerfile, Makefile, and related files to use Rust 1.80.1 as the base image. This change updates the version across various files, ensuring consistency in the newly released version.

[rust release 1.80.1](https://blog.rust-lang.org/2024/08/08/Rust-1.80.1.html)