### PR TITLE
build(rust): bump version to 1.80.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.80.1
+FROM rust:1.81.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.80.1
+ROOT_PARENT_SWITCH_TAG :=1.81.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ support [just](https://github.com/casey/just)
 
 | image version | [just](https://crates.io/crates/just) |
 | ------------- | --------- |
-| 1.80.1        | 1.34.0    |
+| 1.81.0        | 1.35.0    |
 
 #### cargo-bak
 
@@ -66,10 +66,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.80.1 build env
+# check 1.81.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.80.1 \
+  sinlov/rust-runtime-debian:1.81.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -88,7 +88,7 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.80.1`
+- rust version `1.81.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.80.1
+FROM rust:1.81.0
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.80.1
+FROM rust:1.81.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.80.1",
+  "version": "1.81.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
feat #34

Update the Rust parent image from v1.80.1 to v1.81.0 in Dockerfile, build.dockerfile, and associated documentation. This update includes adjustments in Makefile and README.md to reflect the new image version and its impact on the environment.