### PR TITLE
feat(rust): update Rust version to 1.85.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.84.1
+FROM rust:1.85.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.84.1
+ROOT_PARENT_SWITCH_TAG :=1.85.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ support [just](https://github.com/casey/just)
 
 | image version | [just](https://crates.io/crates/just) |
 | ------------- | --------- |
+| latest        | 1.39.0    |
 | 1.84.1        | 1.39.0    |
-| 1.84.0        | 1.38.0    |
 | 1.83.0        | 1.38.0    |
 | 1.82.0        | 1.36.0    |
 | 1.81.0        | 1.35.0    |
@@ -41,6 +41,7 @@ support [just](https://github.com/casey/just)
 
 | image version | [cargo-bak](https://crates.io/crates/cargo-bak) |
 | ------------- | --------- |
+| latest        | 0.1.5     |
 | 1.75.0+       | 0.1.5     |
 | 1.74.0        | 0.1.4     |
 
@@ -76,10 +77,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.84.1 build env
+# check 1.85.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.84.1 \
+  sinlov/rust-runtime-debian:1.85.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -98,7 +99,7 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.84.1`
+- rust version `1.85.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.84.1
+FROM rust:1.85.0
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.84.1
+FROM rust:1.85.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.84.1",
+  "version": "1.85.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
feat #47

- Update Rust base image from 1.84.1 to 1.85.0 in Dockerfile
- Update Rust version in Makefile and README.md
- Update package.json version to 1.85.0
- Update build-just.dockerfile and build.dockerfile to use Rust 1.85.0