### PR TITLE
feat(rust): update Rust version to 1.86.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.85.1
+FROM rust:1.86.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.85.1
+ROOT_PARENT_SWITCH_TAG :=1.86.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ support [just](https://github.com/casey/just)
 | image version | [just](https://crates.io/crates/just) |
 | ------------- | --------- |
 | latest        | 1.40.0    |
+| 1.86.0        | 1.40.0    |
 | 1.85.1        | 1.40.0    |
 | 1.85.0        | 1.39.0    |
 | 1.84.1        | 1.39.0    |
@@ -79,10 +80,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.85.1 build env
+# check 1.86.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.85.1 \
+  sinlov/rust-runtime-debian:1.86.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -101,7 +102,7 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.85.1`
+- rust version `1.86.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.85.1
+FROM rust:1.86.0
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.85.1
+FROM rust:1.86.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.85.1",
+  "version": "1.86.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
- Update Rust base image from 1.85.1 to 1.86.0 in Dockerfile
- Update Rust version in Makefile and README.md
- Update package.json version to 1.86.0
- Update build-just.dockerfile and build.dockerfile to use Rust 1.86.0