### PR TITLE
update Rust version to 1.87.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN export CARGO_HTTP_DEBUG=true \
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse && \
   rustup component add rustfmt && \
   rustup component add clippy && \
-  rustup component add rls && \
   rustup component add rust-analysis && \
   rustup component add rust-src && \
   cargo install --all-features --version 0.1.5 cargo-bak && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.86.0
+FROM rust:1.87.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.86.0
+ROOT_PARENT_SWITCH_TAG :=1.87.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -31,22 +31,22 @@ support [just](https://github.com/casey/just)
 
 | image version | [just](https://crates.io/crates/just) |
 | ------------- | --------- |
-| latest        | 1.40.0    |
-| 1.86.0        | 1.40.0    |
-| 1.85.1        | 1.40.0    |
-| 1.85.0        | 1.39.0    |
-| 1.84.1        | 1.39.0    |
-| 1.83.0        | 1.38.0    |
-| 1.82.0        | 1.36.0    |
-| 1.81.0        | 1.35.0    |
+| image:latest        | 1.40.0    |
+| image:1.86.0        | 1.40.0    |
+| image:1.85.1        | 1.40.0    |
+| image:1.85.0        | 1.39.0    |
+| image:1.84.1        | 1.39.0    |
+| image:1.83.0        | 1.38.0    |
+| image:1.82.0        | 1.36.0    |
+| image:1.81.0        | 1.35.0    |
 
 #### cargo-bak
 
 | image version | [cargo-bak](https://crates.io/crates/cargo-bak) |
 | ------------- | --------- |
-| latest        | 0.1.5     |
-| 1.75.0+       | 0.1.5     |
-| 1.74.0        | 0.1.4     |
+| image:latest        | 0.1.5     |
+| image:1.75.0+       | 0.1.5     |
+| image:1.74.0        | 0.1.4     |
 
 ### waring
 
@@ -80,10 +80,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.86.0 build env
+# check 1.87.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.86.0 \
+  sinlov/rust-runtime-debian:1.87.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -102,11 +102,16 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.86.0`
+- rust version `1.87.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 
-release log at: [https://blog.rust-lang.org/](https://blog.rust-lang.org/)
+release at:
+
+- rust official latest version [![](https://img.shields.io/docker/v/_/rust/latest?label=rust&logo=rust&style=social)](https://hub.docker.com/_/rust/tags)
+- [https://blog.rust-lang.org/releases/](https://blog.rust-lang.org/releases/)
+- release manifests [https://static.rust-lang.org/manifests.txt](https://static.rust-lang.org/manifests.txt)
+- Rust Changelogs [https://releases.rs/](https://releases.rs/)
 
 ### dev mode
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 - install component
   - [rustfmt](https://github.com/rust-lang/rustfmt)
   - [clippy](https://doc.rust-lang.org/clippy/)
-  - [rls](https://github.com/rust-lang/rls)
   - [rust-analysis](https://github.com/rust-lang/rust-analyzer)
   - [rust-src](https://github.com/rust-lang/rust)
+  - ~~[rls](https://github.com/rust-lang/rls)~~ remove at 1.87.0
 
 ### build kit version
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   - [clippy](https://doc.rust-lang.org/clippy/)
   - [rust-analysis](https://github.com/rust-lang/rust-analyzer)
   - [rust-src](https://github.com/rust-lang/rust)
-  - ~~[rls](https://github.com/rust-lang/rls)~~ remove at 1.87.0
+  - ~~[rls](https://github.com/rust-lang/rls)~~ removed after image:1.87.0
 
 ### build kit version
 

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -28,7 +28,6 @@ RUN export CARGO_HTTP_DEBUG=true \
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse && \
   rustup component add rustfmt && \
   rustup component add clippy && \
-  rustup component add rls && \
   rustup component add rust-analysis && \
   rustup component add rust-src && \
   cargo install --all-features --version 0.1.5 cargo-bak && \

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.86.0
+FROM rust:1.87.0
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.86.0
+FROM rust:1.87.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -34,7 +34,6 @@ RUN export CARGO_HTTP_DEBUG=true \
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse && \
   rustup component add rustfmt && \
   rustup component add clippy && \
-  rustup component add rls && \
   rustup component add rust-analysis && \
   rustup component add rust-src && \
   cargo install --all-features --version 0.1.5 cargo-bak && \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.86.0",
+  "version": "1.87.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
- Update Rust base image from 1.86.0 to 1.87.0 in Dockerfile
- Update version in Makefile and package.json
- Update README.md with new version information
- Update build-just.dockerfile and build.dockerfile to use Rust 1.87.0
- Remove rustup component add rls command from Dockerfile
- This change reduces the image size and build time