### PR TITLE
feat(rust): update Rust version to 1.88.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.87.0
+FROM rust:1.88.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.87.0
+ROOT_PARENT_SWITCH_TAG :=1.88.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
   - [rust-analysis](https://github.com/rust-lang/rust-analyzer)
   - [rust-src](https://github.com/rust-lang/rust)
   - ~~[rls](https://github.com/rust-lang/rls)~~ removed after image:1.87.0
+- environment
+  - [CARGO_CACHE_AUTO_CLEAN_FREQUENCY](https://doc.rust-lang.org/stable/cargo/reference/config.html#cacheauto-clean-frequency) `never` after image:1.88.0
 
 ### build kit version
 
@@ -80,10 +82,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.87.0 build env
+# check 1.88.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.87.0 \
+  sinlov/rust-runtime-debian:1.88.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -102,7 +104,7 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.87.0`
+- rust version `1.88.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.87.0
+FROM rust:1.88.0
 
 #USER root
 
@@ -21,6 +21,8 @@ ENV CARGO_HTTP_TIMEOUT=300
 ENV CARGO_HTTP_MULTIPLEXING=false
 ENV CARGO_TERM_PROGRESS_WHEN=never
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# https://doc.rust-lang.org/stable/cargo/reference/config.html#cacheauto-clean-frequency
+ENV CARGO_CACHE_AUTO_CLEAN_FREQUENCY=never
 ENV CI=1
 
 # add component

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.87.0
+FROM rust:1.88.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo
@@ -27,6 +27,8 @@ ENV CARGO_HTTP_TIMEOUT=300
 ENV CARGO_HTTP_MULTIPLEXING=false
 ENV CARGO_TERM_PROGRESS_WHEN=never
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# https://doc.rust-lang.org/stable/cargo/reference/config.html#cacheauto-clean-frequency
+ENV CARGO_CACHE_AUTO_CLEAN_FREQUENCY=never
 ENV CI=1
 
 # add component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.87.0",
+  "version": "1.88.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
- Update Rust base image from 1.87.0 to 1.88.0 in Dockerfile
- Update version in Makefile and README.md
- Add CARGO_CACHE_AUTO_CLEAN_FREQUENCY environment variable

Starting in 1.88.0, Cargo will automatically run garbage collection on the cache in its home directory!

Cargo introduces a garbage collection mechanism to automatically clean up old files (e.g. .crate files). Cargo will remove files downloaded from the network if not accessed in 3 months, and files obtained from the local system if not accessed in 1 month. Note that this automatic garbage collection will not take place if running offline (using --offline or --frozen).

more info see [https://blog.rust-lang.org/2023/12/11/cargo-cache-cleaning/](https://blog.rust-lang.org/2023/12/11/cargo-cache-cleaning/)