### PR TITLE
feat(rust): update Rust version to 1.89.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.88.0
+FROM rust:1.89.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.88.0
+ROOT_PARENT_SWITCH_TAG :=1.89.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.88.0 build env
+# check 1.89.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.88.0 \
+  sinlov/rust-runtime-debian:1.89.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \
@@ -104,7 +104,7 @@ docker run --rm \
 
 ### each version
 
-- rust version `1.88.0`
+- rust version `1.89.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.88.0
+FROM rust:1.89.0
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.88.0
+FROM rust:1.89.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
- Updated the Rust version in the Dockerfile, build-just.dockerfile, and build.dockerfile to 1.89.0.
- Adjusted the version in the Makefile and package.json to ensure consistency across the project.
- Modified the README.md to reflect the new Rust version for build environment checks.
