### PR TITLE
feat: update Rust version to 1.92.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.91.0
+FROM rust:1.92.0
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.91.0
+ROOT_PARENT_SWITCH_TAG :=1.92.0
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.91.0 build env
+# check 1.92.0 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.91.0 \
+  sinlov/rust-runtime-debian:1.92.0 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.91.0
+FROM rust:1.92.0
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.91.0
+FROM rust:1.92.0
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/doc-dev/dev.md
+++ b/doc-dev/dev.md
@@ -8,7 +8,7 @@
 
 ### each version
 
-- rust version `1.91.0`
+- rust version `1.92.0`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
- Updated the base Rust version in Dockerfiles and Makefile from 1.91.0 to 1.92.0.
- Adjusted the README and documentation to reflect the new version.
- Ensured consistency across all relevant files including package.json and dev documentation.
