### PR TITLE
build(rust): update Rust version to 1.94.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.94.0
+FROM rust:1.94.1
 
 #USER root
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME =rust-runtime-debian
 
 # MakeImage.mk settings start
 ROOT_OWNER =sinlov
-ROOT_PARENT_SWITCH_TAG :=1.94.0
+ROOT_PARENT_SWITCH_TAG :=1.94.1
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =rust
 INFO_BUILD_DOCKER_FILE =Dockerfile

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ docker run --rm \
   just --version && \
   rustup show '
 
-# check 1.94.0 build env
+# check 1.94.1 build env
 docker run --rm \
   --name "test-rust-runtime-debian" \
-  sinlov/rust-runtime-debian:1.94.0 \
+  sinlov/rust-runtime-debian:1.94.1 \
   bash -c ' \
   uname -asrm && \
   cat /etc/os-release && \

--- a/build-just.dockerfile
+++ b/build-just.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.94.0
+FROM rust:1.94.1
 
 #USER root
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -5,7 +5,7 @@
 # maintainer="https://github.com/lord-of-dock/rust-runtime-debian"
 
 # https://hub.docker.com/_/rust/tags?page=1
-FROM rust:1.94.0
+FROM rust:1.94.1
 
 #USER root
 ARG CARGO_HOME=/usr/local/cargo

--- a/doc-dev/dev.md
+++ b/doc-dev/dev.md
@@ -8,7 +8,7 @@
 
 ### each version
 
-- rust version `1.94.0`
+- rust version `1.94.1`
   - change in `Makefile`
   - change in `Dockerfile` or `build.dockerfile`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-runtime-debian",
-  "version": "1.94.0",
+  "version": "1.94.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lord-of-dock/rust-runtime-debian.git"


### PR DESCRIPTION
### Description of Changes

- Updated the base Rust version in Dockerfiles and Makefile to 1.94.1.
- Adjusted the version reference in README.md and documentation files to reflect the new version.
- Ensured consistency across all relevant files to maintain compatibility with the latest Rust features and improvements.

### Related Issues

List related issues here

- #74